### PR TITLE
Add security whitelist/blacklist for executed commands

### DIFF
--- a/src/main/java/fr/vmarchaud/mineweb/bukkit/BukkitCore.java
+++ b/src/main/java/fr/vmarchaud/mineweb/bukkit/BukkitCore.java
@@ -51,6 +51,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.FileHandler;
@@ -232,6 +233,19 @@ public class BukkitCore extends JavaPlugin implements ICore {
 	
 	@Override
 	public void runCommand(String command) {
+		List<String> whitelistedCommands = instance.config().getWhitelistedCommands();
+		boolean blacklist = instance.config().isUseBlacklist();
+		if(whitelistedCommands!=null){
+			boolean startwith = false;
+			for(String whitelistedCommand : whitelistedCommands){
+				if(command.startsWith(whitelistedCommand)) {
+					startwith = true;
+				}
+			}
+			if(blacklist==startwith){
+				return;
+			}
+		}
 		getServer().getScheduler().runTask(this, () -> {
 			getServer().dispatchCommand(getServer().getConsoleSender(), command);
 		});

--- a/src/main/java/fr/vmarchaud/mineweb/bungee/BungeeCore.java
+++ b/src/main/java/fr/vmarchaud/mineweb/bungee/BungeeCore.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.FileHandler;
@@ -221,6 +222,19 @@ public class BungeeCore extends Plugin implements ICore {
 
 	@Override
 	public void runCommand(String command) {
+		List<String> whitelistedCommands = instance.config().getWhitelistedCommands();
+		boolean blacklist = instance.config().isUseBlacklist();
+		if(whitelistedCommands!=null){
+			boolean startwith = false;
+			for(String whitelistedCommand : whitelistedCommands){
+				if(command.startsWith(whitelistedCommand)) {
+					startwith = true;
+				}
+			}
+			if(blacklist==startwith){
+				return;
+			}
+		}
 		getProxy().getPluginManager().dispatchCommand(getProxy().getConsole(), command);
 	}
 

--- a/src/main/java/fr/vmarchaud/mineweb/common/configuration/PluginConfiguration.java
+++ b/src/main/java/fr/vmarchaud/mineweb/common/configuration/PluginConfiguration.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.List;
 
 import fr.vmarchaud.mineweb.common.ICore;
 import lombok.Data;
@@ -18,6 +19,8 @@ public class PluginConfiguration {
 	public String motd;
 	public String domain;
 	public Integer port;
+	public List<String> whitelistedCommands;
+	public boolean useBlacklist;
 
 	public PluginConfiguration(File path) {
 		this.path = path;

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -1,4 +1,4 @@
 name: MinewebBridge
 main: fr.vmarchaud.mineweb.bungee.BungeeCore
-version: 3.0.6
+version: 3.0.7
 author: ThisIsMac, Shyrogan

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: MinewebBridge
 main: fr.vmarchaud.mineweb.bukkit.BukkitCore
-version: 3.0.6
+version: 3.0.7
 api-version: 1.15
 authors:
   - ThisIsMac


### PR DESCRIPTION
2 new configurable options available on the config.json:
- whitelistedCommands: list of whitelisted commands. Only the commands on this list can be executed on the console over the bridge.
- useBlacklist: invert the whitelistedCommands to blacklist system. All commands can be executed over the bridge except the whitelistedCommands list.
- if whitelistedCommands is set to null, this will disable the whitelist/blacklist system
This system is disabled by default.